### PR TITLE
admin getall orders method is editted

### DIFF
--- a/src/main/java/com/onlineShop/bootcamp/controller/order/OrderController.java
+++ b/src/main/java/com/onlineShop/bootcamp/controller/order/OrderController.java
@@ -4,17 +4,12 @@ import com.onlineShop.bootcamp.common.ApiResponse;
 import com.onlineShop.bootcamp.dto.order.OrderPreviewResponse;
 import com.onlineShop.bootcamp.dto.order.OrderRequest;
 import com.onlineShop.bootcamp.dto.order.OrderResponse;
-import com.onlineShop.bootcamp.dto.user.UserResponse;
-import com.onlineShop.bootcamp.entity.User;
 import com.onlineShop.bootcamp.service.order.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-import java.util.Map;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
@@ -41,9 +36,9 @@ public class OrderController {
         return ResponseEntity.ok(new ApiResponse<>(true, "Order is created", orderService.createOrder(orderRequest)));
     }
 
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<ApiResponse<List<OrderResponse>>> getUserOrders(@PathVariable Long userId) {
-        return ResponseEntity.ok(new ApiResponse<>(true, "Order list are fetched for the user", orderService.getUserOrders(userId)));
+    @GetMapping("/orders")
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getUserOrders() {
+        return ResponseEntity.ok(new ApiResponse<>(true, "Order list are fetched for the user", orderService.getUserOrders()));
     }
 
 }

--- a/src/main/java/com/onlineShop/bootcamp/service/order/OrderService.java
+++ b/src/main/java/com/onlineShop/bootcamp/service/order/OrderService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface OrderService {
     OrderResponse createOrder(OrderRequest orderRequest);
-    List<OrderResponse> getUserOrders(Long userId);
+    List<OrderResponse> getUserOrders();
     List<OrderResponse> getAllOrders();
     OrderPreviewResponse previewOrder(OrderRequest orderRequest);
 }


### PR DESCRIPTION
This pull request refactors how user orders are fetched in the order service and controller. The main change is that the endpoint for retrieving a user's orders now uses the authentication token to identify the user, rather than requiring the user ID as a path parameter. This improves security and simplifies the API for clients.

**Controller and Service API changes:**

* The `getUserOrders` endpoint in `OrderController` was changed from `/user/{userId}` to `/orders`, and it no longer requires a user ID parameter. The controller now calls the service method without a user ID.
* The `OrderService` interface method `getUserOrders(Long userId)` was replaced with `getUserOrders()`, removing the need for the user ID argument.

**Authentication and logic updates:**

* In `OrderServiceImp`, the implementation of `getUserOrders` now extracts the user ID from the JWT token provided in the `Authorization` header, rather than accepting it as a method argument. This change enforces that users can only fetch their own orders.

**Code cleanup:**

* Unused imports related to user entities and security context were removed from `OrderController.java`, reflecting the updated logic.
* Minor whitespace and formatting cleanup in `OrderServiceImp.java` for better readability.