### PR TITLE
supplier module is created

### DIFF
--- a/src/main/java/com/onlineShop/bootcamp/controller/supplier/SupplierController.java
+++ b/src/main/java/com/onlineShop/bootcamp/controller/supplier/SupplierController.java
@@ -1,0 +1,32 @@
+package com.onlineShop.bootcamp.controller.supplier;
+
+
+import com.onlineShop.bootcamp.common.ApiResponse;
+import com.onlineShop.bootcamp.dto.supplier.SupplierRequest;
+import com.onlineShop.bootcamp.dto.supplier.SupplierResponse;
+import com.onlineShop.bootcamp.service.supplier.SupplierService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/suppliers")
+@RequiredArgsConstructor
+public class SupplierController {
+
+    private final SupplierService supplierService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SupplierResponse>> createSupplier(@RequestBody SupplierRequest supplierRequest) {
+        SupplierResponse response = supplierService.createSupplier(supplierRequest);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Supplier created",response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SupplierResponse>>> getAllSuppliers() {
+        return ResponseEntity.ok(new ApiResponse<>(true, "Supplier created",supplierService.getAllSuppliers()));
+    }
+
+}

--- a/src/main/java/com/onlineShop/bootcamp/dto/supplier/SupplierRequest.java
+++ b/src/main/java/com/onlineShop/bootcamp/dto/supplier/SupplierRequest.java
@@ -1,0 +1,14 @@
+package com.onlineShop.bootcamp.dto.supplier;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SupplierRequest {
+    private String name;
+}

--- a/src/main/java/com/onlineShop/bootcamp/dto/supplier/SupplierResponse.java
+++ b/src/main/java/com/onlineShop/bootcamp/dto/supplier/SupplierResponse.java
@@ -1,0 +1,15 @@
+package com.onlineShop.bootcamp.dto.supplier;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SupplierResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/onlineShop/bootcamp/mapper/SupplierMapper.java
+++ b/src/main/java/com/onlineShop/bootcamp/mapper/SupplierMapper.java
@@ -1,0 +1,18 @@
+package com.onlineShop.bootcamp.mapper;
+
+import com.onlineShop.bootcamp.dto.supplier.SupplierResponse;
+import com.onlineShop.bootcamp.entity.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SupplierMapper {
+
+    public static SupplierResponse toSupplierResponse(Supplier supplier){
+
+        return new SupplierResponse(
+                supplier.getId(),
+                supplier.getName()
+        );
+    }
+
+}

--- a/src/main/java/com/onlineShop/bootcamp/repository/SupplierRepository.java
+++ b/src/main/java/com/onlineShop/bootcamp/repository/SupplierRepository.java
@@ -1,0 +1,7 @@
+package com.onlineShop.bootcamp.repository;
+
+import com.onlineShop.bootcamp.entity.Supplier;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SupplierRepository extends JpaRepository<Supplier, Long> {
+}

--- a/src/main/java/com/onlineShop/bootcamp/service/supplier/SupplierService.java
+++ b/src/main/java/com/onlineShop/bootcamp/service/supplier/SupplierService.java
@@ -1,0 +1,11 @@
+package com.onlineShop.bootcamp.service.supplier;
+
+import com.onlineShop.bootcamp.dto.supplier.SupplierRequest;
+import com.onlineShop.bootcamp.dto.supplier.SupplierResponse;
+
+import java.util.List;
+
+public interface SupplierService {
+    List<SupplierResponse> getAllSuppliers();
+    SupplierResponse createSupplier(SupplierRequest supplierRequest);
+}

--- a/src/main/java/com/onlineShop/bootcamp/service/supplier/SupplierServiceImp.java
+++ b/src/main/java/com/onlineShop/bootcamp/service/supplier/SupplierServiceImp.java
@@ -1,0 +1,39 @@
+package com.onlineShop.bootcamp.service.supplier;
+
+import com.onlineShop.bootcamp.dto.supplier.SupplierRequest;
+import com.onlineShop.bootcamp.dto.supplier.SupplierResponse;
+import com.onlineShop.bootcamp.entity.Supplier;
+import com.onlineShop.bootcamp.mapper.SupplierMapper;
+import com.onlineShop.bootcamp.repository.SupplierRepository;
+import com.onlineShop.bootcamp.service.order.OrderServiceImp;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SupplierServiceImp implements SupplierService{
+
+    private final SupplierRepository supplierRepository;
+    private static Logger logger = LoggerFactory.getLogger(OrderServiceImp.class);
+
+    @Override
+    public List<SupplierResponse> getAllSuppliers() {
+        logger.info("Fetching all suppliers ");
+        return supplierRepository.findAll().stream().map(SupplierMapper::toSupplierResponse).toList();
+    }
+
+    @Override
+    public SupplierResponse createSupplier(SupplierRequest supplierRequest) {
+        Supplier supplier = new Supplier();
+        supplier.setName(supplierRequest.getName());
+
+        Supplier savedSupplier = supplierRepository.save(supplier);
+        logger.info("Creating a supplier ");
+        return SupplierMapper.toSupplierResponse(savedSupplier);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new supplier management feature to the project, enabling the creation and retrieval of supplier information via a REST API. The changes include new controller, service, DTO, mapper, and repository classes to support supplier operations.

### Supplier API Implementation

* Added `SupplierController` to handle HTTP requests for creating and retrieving suppliers. It exposes endpoints for POST (create) and GET (list all) operations.
* Introduced `SupplierService` interface and its implementation `SupplierServiceImp` to encapsulate business logic for supplier management, including logging and interaction with the repository. [[1]](diffhunk://#diff-6a58da3aad6c5192e8a07d802fe76c73821b117ff3ee1425d4eea56fccafa2b4R1-R11) [[2]](diffhunk://#diff-c50eff2c8d030f30429f8451e4a34e677523ac40c4be3e450ff6658087eb030fR1-R39)

### Data Transfer and Mapping

* Created DTO classes `SupplierRequest` and `SupplierResponse` for request and response payloads in supplier-related API operations. [[1]](diffhunk://#diff-a27c12256120223649670daf90008b97feadcbc3be12e768ecc86d8f4dfa735bR1-R14) [[2]](diffhunk://#diff-a3dd98469c58338d242e3f901e797a7fde692ab16664e7ccfa9490fd5c04c3caR1-R15)
* Added `SupplierMapper` to convert between `Supplier` entities and `SupplierResponse` DTOs.

### Persistence Layer

* Added `SupplierRepository` interface extending `JpaRepository` to handle supplier data persistence.